### PR TITLE
Array fix

### DIFF
--- a/fits2db.c
+++ b/fits2db.c
@@ -163,6 +163,7 @@ char   *dbname          = NULL;         // database name name (MySQL create)
 char   *addname         = NULL;         // column name to be added
 
 char    delimiter       = DEF_DELIMITER;// default to CSV
+char	arr_delimiter 	= DEF_DELIMITER;// default to CSV
 char    quote_char      = DEF_QUOTE;    // string quote character
 char   *omode           = DEF_MODE;     // output file mode
 
@@ -1660,10 +1661,10 @@ dl_printLogical (unsigned char *dp, ColPtr col)
                 olen += len;
                 optr += len;
                 if (col->repeat > 1 && j < col->ncols)
-                    *optr++ = delimiter,  olen++;
+                    *optr++ = arr_delimiter,  olen++;
             }
             if (col->repeat > 1 && i < col->nrows)
-                *optr++ = delimiter,  olen++;
+                *optr++ = arr_delimiter,  olen++;
         }
     }
 
@@ -1732,10 +1733,10 @@ dl_printByte (unsigned char *dp, ColPtr col)
                 olen += len;
                 optr += len;
                 if (col->repeat > 1 && j < col->ncols)
-                    *optr++ = delimiter,  olen++;
+                    *optr++ = arr_delimiter,  olen++;
             }
             if (col->repeat > 1 && i < col->nrows)
-                *optr++ = delimiter,  olen++;
+                *optr++ = arr_delimiter,  olen++;
         }
     }
 
@@ -1802,10 +1803,10 @@ dl_printShort (unsigned char *dp, ColPtr col)
                 optr += len;
                 dp += sz_short;
                 if (col->repeat > 1 && j < col->ncols)
-                    *optr++ = delimiter,  olen++;
+                    *optr++ = arr_delimiter,  olen++;
             }
             if (col->repeat > 1 && i < col->nrows)
-                *optr++ = delimiter,  olen++;
+                *optr++ = arr_delimiter,  olen++;
         }
     }
 
@@ -1872,10 +1873,10 @@ dl_printInt (unsigned char *dp, ColPtr col)
                 optr += len;
                 dp += sz_int;
                 if (col->repeat > 1 && j < col->ncols)
-                    *optr++ = delimiter,  olen++;
+                    *optr++ = arr_delimiter,  olen++;
             }
             if (col->repeat > 1 && i < col->nrows)
-                *optr++ = delimiter,  olen++;
+                *optr++ = arr_delimiter,  olen++;
         }
     }
 
@@ -1935,10 +1936,10 @@ dl_printLong (unsigned char *dp, ColPtr col)
                 optr += len;
                 dp += sz_long;
                 if (col->repeat > 1 && j < col->ncols)
-                    *optr++ = delimiter,  olen++;
+                    *optr++ = arr_delimiter,  olen++;
             }
             if (col->repeat > 1 && i < col->nrows)
-                *optr++ = delimiter,  olen++;
+                *optr++ = arr_delimiter,  olen++;
         }
     }
 
@@ -2025,10 +2026,10 @@ dl_printFloat (unsigned char *dp, ColPtr col)
                 }
                 dp += sz_float;
                 if (col->repeat > 1 && j < col->ncols)
-                    *optr++ = delimiter,  olen++;
+                    *optr++ = arr_delimiter,  olen++;
             }
             if (col->repeat > 1 && i < col->nrows)
-                *optr++ = delimiter,  olen++;
+                *optr++ = arr_delimiter,  olen++;
         }
     }
 
@@ -2115,10 +2116,10 @@ dl_printDouble (unsigned char *dp, ColPtr col)
                 }
                 dp += sz_double;
                 if (col->repeat > 1 && j < col->ncols)
-                    *optr++ = delimiter,  olen++;
+                    *optr++ = arr_delimiter,  olen++;
             }
             if (col->repeat > 1 && i < col->nrows)
-                *optr++ = delimiter,  olen++;
+                *optr++ = arr_delimiter,  olen++;
         }
     }
 

--- a/fits2db.c
+++ b/fits2db.c
@@ -380,16 +380,27 @@ main (int argc, char **argv)
 	    case 'i':  iname = strdup (optval);		break;  // --input
 	    case 'o':  oname = strdup (optval);		break;  // --output
 
-	    case '0':  delimiter = ' ';			break;  // ASV
-	    case '1':  delimiter = '|';			break;  // BSV
-	    case '2':  delimiter = ',';			break;  // CSV
-	    case '3':  delimiter = '\t';		break;  // TSV
+	    case '0':  delimiter = ' ';
+                       arr_delimiter=' ';
+                       break;  // ASV
+	    case '1':  delimiter = '|';
+                       arr_delimiter='|';
+                       break;  // BSV
+	    case '2':  delimiter = ',';
+                       arr_delimiter=',';
+                       break;  // CSV
+	    case '3':  delimiter = '\t';
+                       arr_delimiter='\t';
+                       break;  // TSV
 	    case '4':  delimiter = '|'; 
-                       format = TAB_IPAC; 	        break;
+                       format = TAB_IPAC;
+                       arr_delimiter='|';
+                       break;
 
 	    case '5':  if (optval[0] == 'm') {          // MySQL ouptut
                             format = TAB_MYSQL;
                             delimiter = ',';
+                            arr_delimiter = ',';
                             do_quote = 1;
                             quote_char = '"';
                        } else if (optval[0] == 's') {  // MySQL ouptut
@@ -397,6 +408,7 @@ main (int argc, char **argv)
                        } else {                        // default to Postgres
                             format = TAB_POSTGRES;
                             delimiter = '\t';
+                            arr_delimiter = ',';
                             do_quote = 0;
                        }
                        break;


### PR DESCRIPTION
Hi, 

There is a bug with the way fits2db deals with array columns and at least postgresql output. 
I.e by default fits2db with postgresql output uses the tab delimiter. That means that the fits table with an two columns  where one is an array 
here is a small python code creating such a file
```import astropy.table, numpy as np
x={'x':np.arange(10),'y':np.zeros((10,10))}
tab=astropy.table.Table(x)
tab.write('aa.fits')
```

Then if I try to ingest this into postgres
fits2db will output 
```
./fits2db --sql=postgres ./aa.fits 

COPY  (y,x) from stdin;
{0.0000000000000000     0.0000000000000000      0.0000000000000000      0.0000000000000000      0.0000000000000000      0.0000000000000000      0.0000000000000000      0.0000000000000000      0.0000000000000000      0.0000000000000000}    0
{0.0000000000000000     0.0000000000000000      0.0000000000000000      0.0000000000000000      0.0000000000000000      0.0000000000000000      0.0000000000000000      0.0000000000000000      0.0000000000000000      0.0000000000000000}    1
```
This is however incorrect and will lead to an error

```
$ ./fits2db --table aaa --create --sql=postgres ./aa.fits  | psql wsdb
CREATE TABLE
ERROR:  extra data after last expected column
CONTEXT:  COPY aaa, line 1: "{0.0000000000000000        0.0000000000000000     0.00000000$ ./fits2db --table aaa --create --sql=postgres ./aa.fits  | psql wsdb
CREATE TABLE
ERROR:  extra data after last expected column
CONTEXT:  COPY aaa, line 1: "{0.0000000000000000        0.0000000000000000     0.0000000000000000       0.0000000000000000      0.0000000000000000      0000000000000000      0.0000000000000000      0.00..."
```
Basically the array items need still be separated by comma rather than tab. 

I have patched the issue by creating a separating variable for array column delimiters.

Cheers,
        Sergey